### PR TITLE
Refactor/create user

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { SupabaseAuthStrategy } from './supabase-auth.strategy';
+import { SupabaseSignupStrategy } from './supabase-signup.strategy';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from '../prisma/prisma.module';
@@ -10,8 +11,8 @@ import { PrismaModule } from '../prisma/prisma.module';
     PassportModule.register({ defaultStrategy: 'jwt' }),
     PrismaModule,
   ],
-  providers: [SupabaseAuthStrategy],
+  providers: [SupabaseAuthStrategy, SupabaseSignupStrategy],
   controllers: [],
-  exports: [PassportModule, SupabaseAuthStrategy],
+  exports: [PassportModule, SupabaseAuthStrategy, SupabaseSignupStrategy],
 })
 export class AuthModule {}

--- a/src/auth/guard/jwt-signup.guard.ts
+++ b/src/auth/guard/jwt-signup.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtSignupGuard extends AuthGuard('jwt-signup') {}

--- a/src/auth/supabase-signup.strategy.ts
+++ b/src/auth/supabase-signup.strategy.ts
@@ -1,0 +1,26 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class SupabaseSignupStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-signup',
+) {
+  constructor(private configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.getOrThrow<string>('SUPABASE_JWT_SECRET'),
+    });
+  }
+
+  async validate(payload: any) {
+    if (!payload || !payload.sub || !payload.email) {
+      throw new UnauthorizedException('Invalid Token or Incomplete Payload');
+    }
+
+    return payload;
+  }
+}

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsString,
-  IsEmail,
-  IsBoolean,
-  IsEnum,
-  IsOptional,
-} from 'class-validator';
+import { IsString, IsBoolean, IsEnum, IsOptional } from 'class-validator';
 
 export enum Role {
   USER = 'USER',
@@ -14,16 +8,10 @@ export enum Role {
 
 export class CreateUserDto {
   @IsString()
-  id: string;
-
-  @IsString()
   name: string;
 
   @IsString()
   username: string;
-
-  @IsEmail()
-  email: string;
 
   @IsBoolean()
   @IsOptional()

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -17,13 +17,14 @@ import {
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { JwtSignupGuard } from '../auth/guard/jwt-signup.guard';
 import { RolesGuard } from '../auth/guard/roles.guard';
 import { SignupGuard } from '../auth/guard/signup.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
-import { Express } from 'express';
+import { Express, Request } from 'express';
 import { Roles } from '../auth/decorator/roles.decorator';
 import { Role } from '@prisma/client';
 
@@ -52,10 +53,13 @@ export class UserController {
   }
 
   @Post()
-  @UseGuards(SignupGuard)
+  @UseGuards(SignupGuard, JwtSignupGuard)
   @UsePipes(new ValidationPipe({ whitelist: true }))
-  async create(@Body() data: CreateUserDto) {
-    return this.userService.create(data);
+  async create(
+    @Req() req: Request & { user: { sub: string; email: string } },
+    @Body() data: CreateUserDto,
+  ) {
+    return this.userService.create(req.user.sub, req.user.email, data);
   }
 
   @Patch(':id')

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -18,13 +18,15 @@ export class UserService {
     return user;
   }
 
-  async create(data: CreateUserDto) {
+  async create(id: string, email: string, data: CreateUserDto) {
     const household = await this.prisma.household.create({ data: {} });
     const workplace = await this.prisma.workplace.create({ data: {} });
 
     return this.prisma.user.create({
       data: {
         ...data,
+        id,
+        email,
         role: data.role ?? Role.USER,
         householdId: household.id,
         workplaceId: workplace.id,


### PR DESCRIPTION
- Removed `id` and `email` fields from create-user DTO, as they come from Supabase Auth;
- Created a Supabase signup strategy to validate user creation;
- Created a signup guard to apply jwt security to signup;
- Modified user service and controller, adding the new signup strategy, to pass the id and email from Supabase Auth to create these fields into the Prisma database.